### PR TITLE
Redirect all routes to crypto-tools.andstuff.dev

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://crypto-tools.andstuff.dev",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `vercel.json` with a catch-all permanent redirect (HTTP 308) so every route on the Vercel deployment redirects to https://crypto-tools.andstuff.dev before this repo is archived.

No existing code is modified — the redirect fires at Vercel's edge layer before Next.js processes anything.